### PR TITLE
Backup failed due to Permission deny

### DIFF
--- a/tasks/hsr.yml
+++ b/tasks/hsr.yml
@@ -18,6 +18,8 @@
   file:
     path: "{{ item.value.hsr_backup_directory }}"
     state: directory
+    owner: "{{ item.value.hana_sid|lower }}adm"
+    group: sapsys
   with_dict: "{{ hsr }}"
 
 - name: Create File for Scale-Out Enviornments


### PR DESCRIPTION
[mk-ansible-roles.saphana-hsr : enable backup configuration] failed

# su - rhtadm -c "echo \"\c -i 01 -u SYSTEM -p RedHat1! -d RHT
> BACKUP DATA USING FILE ('RHT')\" | hdbsql"
...
Connected to RHT@localhost:30113
* 447: backup could not be completed: [110090] Error while backing up backup catalog, [2000002] Cannot create root directory "/usr/sap/RHT/HDB01/backup/log/DB_RHT/", rc=13: Permission denied SQLSTATE: HY000

Solution: 
Change owner and group of backup-directory to rhtadm:sapsys

Root cause: 
# ls -ld /usr/sap/RHT/HDB01/backup
drwxr-xr-x. 3 root root 18 May 12 03:43 /usr/sap/RHT/HDB01/backup

- name: create backup-directory
  file:
	path: " item.value.hsr_backup_directory "
	state: directory
  with_dict: " hsr "