### PR TITLE
switch from sapcontrol to HDB to await shutdown of secondary node

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,8 +72,7 @@
 
 - name: Ensure HANA instance is stopped in the secondary node
   shell: |
-      /usr/sap/{{ sap_hana_hsr_hana_sid | upper }}/HDB{{ sap_hana_hsr_hana_instance_number }}/exe/sapcontrol \
-      -nr {{ sap_hana_hsr_hana_instance_number }} -function StopSystem
+      /usr/sap/{{ sap_hana_hsr_hana_sid | upper }}/HDB{{ sap_hana_hsr_hana_instance_number }}/HDB stop
   args:
     executable: /bin/bash
   become: yes


### PR DESCRIPTION
On my test systems the setup of the system replication failed regularly. The playbook is using `sapcontrol -function StopSystem` which doesn't wait until the database is down. The following `hdbnsutil -sr_register` fails with an error indicating the database is still up.

Since the playbook doesn't check any state of the system, a rerun will fail since the primary is already in replication mode.

As a quick workaround, I switched to `HDB stop`, which waits until the database is completely down.

We might consider a more robust approach as used in the [mk-ansible-roles/saphana-hsr](https://github.com/mk-ansible-roles/saphana-hsr/blob/master/templates/hsr_sr_register.sh.j2#L27) role, checking the states of both databases.

Hope this helps,
Beat