### PR TITLE
adding become_user: sidadm for key file copy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 sap_hana_hsr_rep_mode: sync
 sap_hana_hsr_oper_mode: logreplay
+sap_hana_hsr_hana_sid: "{{ sap_hana_sid }}"
+sap_hana_hsr_alias:
+sap_hana_hsr_hana_instance_number: "{{ sap_hana_instance_number }}"
+sap_hana_hsr_hana_primary_hostname:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: Ensure system PKI SSFS store in the secondary Node matches with the primary Node - pulling
+  become: yes
+  become_user: "{{ sap_hana_hsr_hana_sid | lower }}adm"
   fetch:
     src: "{{ item }}"
     dest: /tmp/
@@ -12,6 +14,8 @@
     - sap_hana_hsr_role == 'primary'
 
 - name: Ensure system PKI SSFS store in the secondary Node matches with the primary Node - pushing
+  become: yes
+  become_user: "{{ sap_hana_hsr_hana_sid | lower }}adm"
   copy:
     src: "/tmp/{{ item.file }}"
     dest: "{{ item.path }}{{ item.file }}"


### PR DESCRIPTION
I am running into permission issues. The file are created by sidadm user so it can be read and copied by the sidadm user. 
To change this I have added become_user: sidadm
This works fine even with MTR